### PR TITLE
Use prop-types module for React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
-    "mediaquery": "0.0.4"
+    "mediaquery": "0.0.4",
+    "prop-types": "^15.6.0"
   }
 }

--- a/src/rezponsive.jsx
+++ b/src/rezponsive.jsx
@@ -3,7 +3,8 @@ const canUseDOM = !!(
     window.document && window.document.createElement)
 );
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import MQ from 'mediaquery';
 
 function Rezponsive(Element) {


### PR DESCRIPTION
`PropTypes` was extracted into a separate module and it doesn't exist anymore in `react` v16. To make this module work with `react` v16, this PR adds `prop-types` module.