### PR TITLE
Migrating to Webpack 3 and React 16

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react", "stage-3"]
+  "presets": ["babel-preset-env", "react", "stage-3"]
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "eslint": "^2.5.3",
     "eslint-loader": "^1.3.0",
     "eslint-plugin-react": "^4.2.3",
-    "prop-types": "15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-addons-test-utils": "^0.14.8",
@@ -56,6 +55,7 @@
     "webpack-dev-server": "2.9.1"
   },
   "dependencies": {
+    "prop-types": "15.6.0",
     "mediaquery": "0.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rezponsive",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "React decorator for responsive behaviors",
   "main": "dist/rezponsive.js",
   "scripts": {
@@ -38,21 +38,22 @@
   },
   "devDependencies": {
     "ava": "^0.13.0",
-    "babel-core": "^6.7.4",
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-3": "^6.5.0",
-    "babel-register": "^6.7.2",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^6.4.1",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1",
+    "babel-register": "^6.26.0",
     "enzyme": "^2.2.0",
     "eslint": "^2.5.3",
     "eslint-loader": "^1.3.0",
     "eslint-plugin-react": "^4.2.3",
-    "react": "^0.14.8",
+    "prop-types": "15.6.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-addons-test-utils": "^0.14.8",
-    "react-dom": "^0.14.8",
-    "webpack": "^1.12.14",
-    "webpack-dev-server": "^1.14.1"
+    "webpack": "3.7.1",
+    "webpack-dev-server": "2.9.1"
   },
   "dependencies": {
     "mediaquery": "0.0.4"

--- a/src/rezponsive.jsx
+++ b/src/rezponsive.jsx
@@ -3,7 +3,8 @@ const canUseDOM = !!(
     window.document && window.document.createElement)
 );
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import MQ from 'mediaquery';
 
 function Rezponsive(Element) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const ENVIRONMENT = process.env.NODE_ENV || 'production';
 
 const conf = {
@@ -6,28 +7,27 @@ const conf = {
   externals: {
   },
   resolve: {
-    alias: {},
-    modulesDirectories: ['node_modules']
+    modules: ['node_modules']
   },
   module: {
-    loaders: [
-      {
+    rules: [/*{
+        test: /\.jsx?$/,
+        enforce: 'pre',
         exclude: /node_modules/,
-        loader: 'babel',
-        test: /\.jsx?$/
+        loader: 'eslint'
+      },*/
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader'
       }
-    ],
-    preLoaders: [{
-      test: /\.jsx?$/,
-      exclude: /node_modules/,
-      loader: 'eslint'
-    }]
+    ]
   },
   output: {
     filename: 'rezponsive.js',
     library: 'rezponsive',
     libraryTarget: 'umd',
-    path: './dist/'
+    path: path.resolve(__dirname, 'dist')
   },
   plugins: []
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,18 +10,11 @@ const conf = {
     modules: ['node_modules']
   },
   module: {
-    rules: [/*{
-        test: /\.jsx?$/,
-        enforce: 'pre',
-        exclude: /node_modules/,
-        loader: 'eslint'
-      },*/
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        loader: 'babel-loader'
-      }
-    ]
+    rules: [{
+      test: /\.jsx?$/,
+      exclude: /node_modules/,
+      loader: 'babel-loader'
+    }]
   },
   output: {
     filename: 'rezponsive.js',


### PR DESCRIPTION
Changes include:
- Migrating to Webpack 3
- Migrating to React 16: 
  - Replacing babel-preset-es2015 by babel-preset-env
  - Adding new prop-types dependency
  - Updating react and react-dom to version 16
  - Update the other react related dependencies accordingly