### PR TITLE
feat: add disableListeners option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,6 @@ const Component = RezponsiveConsumer(({ currentMedia, isTouch }) => (
 </MyApp>
 
 ```
+
+In case you want to use an external listener to update `clientMedia`, you can
+set the `disableListeners` prop to `true` and manually update `clientMedia`.

--- a/example/index.js
+++ b/example/index.js
@@ -92,6 +92,36 @@ render(
         }}
       />
     </RezponsiveApp>
+    <RezponsiveApp
+      mq={{
+        s: 320,
+        m: 720,
+        l: 1024,
+        xl: Infinity,
+        portrait: '(orientation: portrait)',
+        landscape: '(orientation: landscape)',
+      }}
+      clientMedia={{
+        s: false,
+        m: true,
+        l: false,
+        xl: false,
+        portrait: true,
+        landscape: false,
+      }}
+      disableListeners
+    >
+      <ConsumerExample
+        mq={{
+          s: 320,
+          m: 720,
+          l: 1024,
+          xl: Infinity,
+          portrait: '(orientation: portrait)',
+          landscape: '(orientation: landscape)',
+        }}
+      />
+    </RezponsiveApp>
   </div>,
   document.getElementById('rezponsive-example'),
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rezponsive",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "React decorator for responsive behaviors",
   "main": "cjs/rezponsive.js",
   "scripts": {

--- a/src/rezponsive.jsx
+++ b/src/rezponsive.jsx
@@ -106,6 +106,7 @@ export default function Rezponsive(Element) {
     }
 
     componentDidMount() {
+      if (this.props.disableListeners) return;
       this.updateMediaQueries();
       const { mm, mq } = this.state;
 
@@ -169,6 +170,7 @@ export default function Rezponsive(Element) {
     isTouchOnServer: PropTypes.bool,
     serverMedia: PropTypes.object,
     clientMedia: PropTypes.object,
+    disableListeners: PropTypes.bool,
   };
 
   RezponsiveComponent.defaultProps = {
@@ -178,6 +180,7 @@ export default function Rezponsive(Element) {
       all: true,
     },
     clientMedia: null,
+    disableListeners: false,
   };
 
   return RezponsiveComponent;


### PR DESCRIPTION
Add disableListener prop to skip matchMedia listener creation.
Context will be regularly updated when manually updating clientMedia.
`isTouch` remains internally derived from client as it does not implies expensive listeners.